### PR TITLE
Improve Compute View

### DIFF
--- a/src/lib/layouts/ShellPageHeader.svelte
+++ b/src/lib/layouts/ShellPageHeader.svelte
@@ -22,7 +22,8 @@
 			<p class="text-surface-700-300">{settings.description}</p>
 		</div>
 	</div>
-	<div class="self-start lg:self-end">
+
+	<div class="self-start lg:self-end flex gap-4">
 		{@render tools?.()}
 	</div>
 </div>

--- a/src/routes/(shell)/compute/clusters/create/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/create/+page.svelte
@@ -108,7 +108,9 @@
 
 		Clients.compute()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersPost(parameters)
-			.then(() => window.location.assign('/compute/clusters'))
+			.then((v: Compute.ComputeClusterRead) =>
+				window.location.assign('/compute/clusters/view/' + v.metadata.id)
+			)
 			.catch((e: Error) => Clients.error(e));
 	}
 

--- a/src/routes/(shell)/compute/clusters/edit/[id]/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/edit/[id]/+page.svelte
@@ -154,6 +154,7 @@
 </script>
 
 <ShellPageHeader {settings} />
+
 <ShellViewHeader metadata={resource.metadata}>
 	{#snippet badges()}
 		<Badge icon={RegionUtil.icon(data.regions, resource.spec.regionId)}>


### PR DESCRIPTION
It's annoying having to click around for things, especially SSH IDs and delete buttons from this point.  Also on creation go straight to the view as it shows status of everything and gives you access to IP addresses which is a much better UX.