### PR TITLE
Fix Logos On Chrome

### DIFF
--- a/src/lib/logos/Logo.svelte
+++ b/src/lib/logos/Logo.svelte
@@ -23,16 +23,16 @@
 		const parser = new DOMParser();
 
 		const svg = parser.parseFromString(raw, 'image/svg+xml');
-		if (!svg.activeElement) return;
+		if (!svg.firstElementChild) return;
 
 		for (const cls of (props.class || '').split(' ')) {
-			svg.activeElement.classList.add(cls);
+			svg.firstElementChild.classList.add(cls);
 		}
 
 		const elem = document.getElementById('logo');
 		if (!elem) return;
 
-		elem.replaceWith(svg.activeElement);
+		elem.replaceWith(svg.firstElementChild);
 	}
 
 	if (env.PUBLIC_LOGO) {
@@ -42,8 +42,6 @@
 
 {#if env.PUBLIC_LOGO}
 	<div id="logo"></div>
-
-	<!--<img class={props.class || ''} src={env.PUBLIC_LOGO} alt="logo" />-->
 {:else}
 	<svg
 		width="200"


### PR DESCRIPTION
Using activeElement is wrong as it's used to point to the thing that has focus.  On Chrome/Edge this isn't set, where it is on Firefox.  Using firstChildElement seems to be more appropriate!