### PR TITLE
Fix Release Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches-ignore:
-      - '*'
+      - '**'
     tags:
       - '*'
 permissions:


### PR DESCRIPTION
Use the super glob to ignore branch pushed with a / in them to avoid running spurious release jobs when dependency-bot does what it does.