### PR TITLE
Fix Compute's View of Flavors/Images

### DIFF
--- a/src/routes/(shell)/compute/clusters/create/+page.ts
+++ b/src/routes/(shell)/compute/clusters/create/+page.ts
@@ -14,16 +14,12 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 		error(400, 'region ID not in query');
 	}
 
-	const images = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(
-		{
-			organizationID: organizationID,
-			regionID: regionID
-		}
-	);
+	const images = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
+		organizationID: organizationID,
+		regionID: regionID
+	});
 
-	const flavors = Clients.kubernetes(
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
+	const flavors = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,
 		regionID: regionID
 	});

--- a/src/routes/(shell)/compute/clusters/edit/[id]/+page.ts
+++ b/src/routes/(shell)/compute/clusters/edit/[id]/+page.ts
@@ -22,16 +22,12 @@ export const load: PageLoad = async ({ fetch, parent, params }) => {
 
 	const names = otherProjectClusters.map((x) => x.metadata.name);
 
-	const images = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(
-		{
-			organizationID: organizationID,
-			regionID: cluster.spec.regionId
-		}
-	);
+	const images = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
+		organizationID: organizationID,
+		regionID: cluster.spec.regionId
+	});
 
-	const flavors = Clients.kubernetes(
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
+	const flavors = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,
 		regionID: cluster.spec.regionId
 	});


### PR DESCRIPTION
This was using the Kubernetes view of these resources, not the compute one!