### PR TITLE
Loosen Naming Constraints

### DIFF
--- a/src/lib/ComputeWorkloadPool.svelte
+++ b/src/lib/ComputeWorkloadPool.svelte
@@ -135,7 +135,7 @@
 
 	// Pool is valid if the name is.
 	$effect.pre(() => {
-		valid = Validation.kubernetesNameValid(pool.name);
+		valid = Validation.kubernetesLabelValueValid(pool.name);
 	});
 
 	function newFirewallRule(): Compute.FirewallRule {
@@ -188,8 +188,8 @@
 	<ShellSection title="Pool Metadata">
 		<TextInput
 			label="Choose a name for your workload pool."
-			hint="Name should be unique, contain 0-9, a-z, . or - and be at most 63 characters."
-			validators={Validation.GetKubernetesNameValidators([])}
+			hint={Validation.kubernetesLabelValueHint}
+			validators={Validation.GetKubernetesLabelValueValidators([])}
 			bind:value={pool.name}
 			bind:valid
 		/>

--- a/src/lib/KubernetesWorkloadPool.svelte
+++ b/src/lib/KubernetesWorkloadPool.svelte
@@ -65,7 +65,7 @@
 	}
 
 	$effect.pre(() => {
-		valid = Validation.kubernetesNameValid(pool.name);
+		valid = Validation.kubernetesLabelValueValid(pool.name);
 	});
 
 	function lookupFlavor(id: string): Kubernetes.Flavor {
@@ -76,8 +76,8 @@
 <ShellSection title="Pool Metadata">
 	<TextInput
 		label="Choose a name for your workload pool."
-		hint="Name should be unique, contain 0-9, a-z, . or - and be at most 63 characters."
-		validators={Validation.GetKubernetesNameValidators([])}
+		hint={Validation.kubernetesLabelValueHint}
+		validators={Validation.GetKubernetesLabelValueValidators([])}
 		bind:value={pool.name}
 		bind:valid
 	/>

--- a/src/lib/VirtualKubernetesWorkloadPool.svelte
+++ b/src/lib/VirtualKubernetesWorkloadPool.svelte
@@ -31,7 +31,7 @@
 	});
 
 	$effect.pre(() => {
-		valid = Validation.kubernetesNameValid(pool.name);
+		valid = Validation.kubernetesLabelValueValid(pool.name);
 	});
 
 	function lookupFlavor(id: string): Kubernetes.Flavor {
@@ -42,8 +42,8 @@
 <ShellSection title="Pool Metadata">
 	<TextInput
 		label="Choose a name for your workload pool."
-		hint="Name should be unique, contain 0-9, a-z, . or - and be at most 63 characters."
-		validators={Validation.GetKubernetesNameValidators([])}
+		hint={Validation.kubernetesLabelValueHint}
+		validators={Validation.GetKubernetesLabelValueValidators([])}
 		bind:value={pool.name}
 		bind:valid
 	/>

--- a/src/lib/layouts/ShellMetadataSection.svelte
+++ b/src/lib/layouts/ShellMetadataSection.svelte
@@ -23,8 +23,8 @@
 	<TextInput
 		bind:value={metadata.name}
 		label="Resource name."
-		hint="Name should be unique, contain 0-9, a-z, . or - and be at most 63 characters."
-		validators={Validation.GetKubernetesNameValidators(names)}
+		hint={Validation.kubernetesLabelValueHint}
+		validators={Validation.GetKubernetesLabelValueValidators(names)}
 		bind:valid
 	/>
 	<TextInput

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -27,7 +27,17 @@ export function kubernetesNameValid(name: string | null | undefined): boolean {
 	if (!name) return false;
 	// RFC-1123.  Must start and end with alphanumeric.
 	// Upto 63 characters, lower case alpha, numeric and -.
-	return name.match(/^(?!-)[a-z0-9-]{0,62}[a-z0-9]$/) != null;
+	return name.match(/^(?:[a-z0-9][a-z0-9-.]{0,61})?[a-z0-9]$/) != null;
+}
+
+export const kubernetesLabelValueHint =
+	'Must only contain upper and lower case alphanumeric characters, periods, hyphens and underscores, start and end with an alphanueric character, and be no more than 63 characters in length.';
+
+export function kubernetesLabelValueValid(name: string | null | undefined): boolean {
+	if (!name) return false;
+	// RFC-1123.  Must start and end with alphanumeric [0-9a-zA-Z]
+	// Upto 63 characters, may contain [_.-].
+	return name.match(/^(?:[a-zA-Z0-9][a-zA-Z0-9_.-]{0,61})?[a-zA-Z0-9]$/) != null;
 }
 
 export function unique(needle: string, haystack: Array<string> | undefined): boolean {
@@ -37,4 +47,10 @@ export function unique(needle: string, haystack: Array<string> | undefined): boo
 
 export function GetKubernetesNameValidators(names: Array<string> | undefined): StringValidators {
 	return [stringSet, kubernetesNameValid, (name: string) => unique(name, names)];
+}
+
+export function GetKubernetesLabelValueValidators(
+	names: Array<string> | undefined
+): StringValidators {
+	return [stringSet, kubernetesLabelValueValid, (name: string) => unique(name, names)];
 }


### PR DESCRIPTION
Back in the golden era, where names were the primary keys, we were limited to a-z0-9-. for names.  Now we are all label based in order to allow for mutable names, this is expanded to a-zA-Z0-9_-. for names. Expand the regular expressions to cater for this and improve the UX.