### PR TITLE
Use crypto-js (imported elsewhere) for nonce/challenge

### DIFF
--- a/src/routes/oauth2/login/+page.server.ts
+++ b/src/routes/oauth2/login/+page.server.ts
@@ -1,4 +1,6 @@
 import type { PageServerLoad } from './$types';
+import Base64url from 'crypto-js/enc-base64url';
+import CryptoJS  from 'crypto-js';
 
 // This is the first step in authentication, we are going to generate an OIDC
 // nonce and PKCE code verifier, then set them as cookies in the client so we
@@ -6,15 +8,8 @@ import type { PageServerLoad } from './$types';
 // code verifier as we need to use this server-side during code exchange which
 // uses the client secret.
 export const load: PageServerLoad = ({ cookies }) => {
-	const nonceBytes = new Uint8Array(16);
-	crypto.getRandomValues(nonceBytes);
-
-	const nonce = btoa(nonceBytes.toString());
-
-	const codeChallengeVerifierBytes = new Uint8Array(32);
-	crypto.getRandomValues(codeChallengeVerifierBytes);
-
-	const codeChallengeVerifier = btoa(codeChallengeVerifierBytes.toString());
+	const nonce = CryptoJS.lib.WordArray.random(16).toString(Base64url)
+	const codeChallengeVerifier = CryptoJS.lib.WordArray.random(32).toString(Base64url);
 
 	cookies.set('oidc_nonce', nonce, { path: '/' });
 	cookies.set('oidc_code_challenge_verifier', codeChallengeVerifier, { path: '/' });


### PR DESCRIPTION
The code challenge was generated by making an array of random bytes, then base64 encoding the string representation. The string representation of a byte array is like `"123,45,67,54"`; this meant that the base64 encoding could be much too big to be used as a code challenge value, which is specified as `[a-zA-Z0-9_-]{43,128}` (43 characters in the encoded string corresponds to 32 bytes in the input).

If you want to see why it's too long: if each number was > 100, that's 32 * 3 digit characters, plus 31 commas, a total of 127 characters in the unencoded string; base64 encoding adds about a third, taking the encoded string to 170 or so characters.

CryptoJS helpfully has a URL-safe base64 encoding, and (since we're using it already), can generate the random bytes in the same expression.